### PR TITLE
Pathfinding Upgrade 2

### DIFF
--- a/CommunityLib/AIChallenge.cs
+++ b/CommunityLib/AIChallenge.cs
@@ -173,14 +173,7 @@ namespace CommunityLib
             if (challengeData.location != ua.location)
             {
                 Location[] pathTo;
-                if (controlParams.pathfindingDeligate == null)
-                {
-                    pathTo = ua.location.map.getPathTo(ua.location, challengeData.location, ua, safeMove);
-                }
-                else
-                {
-                    pathTo = ModCore.core.pathfinding.getPathTo(ua.location, challengeData.location, controlParams.pathfindingDeligate, ua);
-                }
+                pathTo = ua.location.map.getPathTo(ua.location, challengeData.location, ua, safeMove);
 
                 if (pathTo == null || pathTo.Length < 2)
                 {
@@ -652,14 +645,7 @@ namespace CommunityLib
             if (challengeData.location != ua.location)
             {
                 Location[] pathTo;
-                if (controlParams.pathfindingDeligate == null)
-                {
-                    pathTo = ua.location.map.getPathTo(ua.location, challengeData.location, ua, safeMove);
-                }
-                else
-                {
-                    pathTo = ModCore.core.pathfinding.getPathTo(ua.location, challengeData.location, controlParams.pathfindingDeligate, ua);
-                }
+                pathTo = ua.location.map.getPathTo(ua.location, challengeData.location, ua, safeMove);
                 if (pathTo == null || pathTo.Length < 2)
                 {
                     reasonMsgs?.Add(new ReasonMsg("Cannot find path to challenge", -10000.0));

--- a/CommunityLib/AITask.cs
+++ b/CommunityLib/AITask.cs
@@ -134,14 +134,7 @@ namespace CommunityLib
                     if (taskData.targetLocation != null && taskData.targetLocation != ua.location)
                     {
                         Location[] pathTo;
-                        if (controlParams.pathfindingDeligate == null)
-                        {
-                            pathTo = ua.location.map.getPathTo(ua.location, taskData.targetLocation, ua);
-                        }
-                        else
-                        {
-                            pathTo = ModCore.core.pathfinding.getPathTo(ua.location, taskData.targetLocation, controlParams.pathfindingDeligate, ua);
-                        }
+                        pathTo = ua.location.map.getPathTo(ua.location, taskData.targetLocation, ua);
                         if (pathTo == null || pathTo.Length < 2)
                         {
                             reasonMsgs?.Add(new ReasonMsg("Cannot find path to target location", -10000.0));
@@ -152,15 +145,7 @@ namespace CommunityLib
                 case TargetCategory.SocialGroup:
                     if (taskData.targetSocialGroup != null && ua.location.soc != taskData.targetSocialGroup)
                     {
-                        Location[] pathTo;
-                        if (controlParams.pathfindingDeligate == null)
-                        {
-                            pathTo = ua.location.map.getPathTo(ua.location, taskData.targetSocialGroup, ua);
-                        }
-                        else
-                        {
-                            pathTo = ModCore.core.pathfinding.getPathTo(ua.location, taskData.targetSocialGroup, controlParams.pathfindingDeligate, ua);
-                        }
+                        Location[] pathTo = ua.location.map.getPathTo(ua.location, taskData.targetSocialGroup, ua);
                         if (pathTo == null || pathTo.Length < 2)
                         {
                             reasonMsgs?.Add(new ReasonMsg("Cannot find path to target social group", -10000.0));
@@ -171,15 +156,7 @@ namespace CommunityLib
                 case TargetCategory.Unit:
                     if (taskData.targetUnit != null && ! ua.location.units.Contains(taskData.targetUnit))
                     {
-                        Location[] pathTo;
-                        if (controlParams.pathfindingDeligate == null)
-                        {
-                            pathTo = ua.location.map.getPathTo(ua.location, taskData.targetUnit.location, ua);
-                        }
-                        else
-                        {
-                            pathTo = ModCore.core.pathfinding.getPathTo(ua.location, taskData.targetUnit.location, controlParams.pathfindingDeligate, ua);
-                        }
+                        Location[] pathTo = ua.location.map.getPathTo(ua.location, taskData.targetUnit.location, ua);
                         if (pathTo == null || pathTo.Length < 2)
                         {
                             reasonMsgs?.Add(new ReasonMsg("Cannot find path to target location", -10000.0));

--- a/CommunityLib/AgentAI.cs
+++ b/CommunityLib/AgentAI.cs
@@ -148,8 +148,6 @@ namespace CommunityLib
             public bool includeDangerousFoe;
             public bool includeNotHolyTask;
 
-            public Func<Location[], Location, Unit, bool> pathfindingDeligate;
-
             public bool hideThoughts;
             public DebugProperties debugProperties;
 
@@ -173,7 +171,6 @@ namespace CommunityLib
                         includeDangerousFoe = true;
                         includeNotHolyTask = false;
 
-                        pathfindingDeligate = null;
                         hideThoughts = false;
                         debugProperties = new DebugProperties(false);
                     }
@@ -196,7 +193,6 @@ namespace CommunityLib
                         includeDangerousFoe = true;
                         includeNotHolyTask = false;
 
-                        pathfindingDeligate = null;
                         hideThoughts = false;
                         debugProperties = new DebugProperties(false);
                     }

--- a/CommunityLib/HarmonyPatches.cs
+++ b/CommunityLib/HarmonyPatches.cs
@@ -1709,11 +1709,12 @@ namespace CommunityLib
 
             foreach (Hooks hook in ModCore.core.GetRegisteredHooks())
             {
-                Location[] newPath = hook?.interceptGetPathTo_Location(locA, locB, u, safeMove) ?? null;
+                Location[] newPath = hook.interceptGetPathTo_Location(locA, locB, u, safeMove) ?? null;
 
                 if (newPath != null)
                 {
                     path = newPath;
+                    break;
                 }
             }
 
@@ -1773,11 +1774,12 @@ namespace CommunityLib
 
             foreach (Hooks hook in ModCore.core.GetRegisteredHooks())
             {
-                Location[] newPath = hook?.interceptGetPathTo_SocialGroup(loc, sg, u, safeMove) ?? null;
+                Location[] newPath = hook.interceptGetPathTo_SocialGroup(loc, sg, u, safeMove) ?? null;
 
                 if (newPath != null)
                 {
                     path = newPath;
+                    break;
                 }
             }
 

--- a/CommunityLib/HarmonyPatches.cs
+++ b/CommunityLib/HarmonyPatches.cs
@@ -1815,7 +1815,26 @@ namespace CommunityLib
             {
                 if (u.location.settlement is Set_MinorOther && u.location.settlement.subs.Any(sub => sub is Sub_Wonder_Doorway))
                 {
-                    Location tomb = __instance.locations.FirstOrDefault(l => l.settlement is Set_TombOfGods);
+                    Location tomb = null;
+
+                    foreach (Location location in __instance.locations)
+                    {
+                        if (location.settlement is Set_TombOfGods)
+                        {
+                            tomb = location;
+                            break;
+                        }
+
+                        foreach (Hooks hook in ModCore.core.GetRegisteredHooks())
+                        {
+                            if (hook.onEvent_IsLocationElderTomb(location))
+                            {
+                                tomb = location;
+                                break;
+                            }
+                        }
+                    }
+
                     if (tomb != null && loc == tomb)
                     {
                         theEntrance = true;

--- a/CommunityLib/Hooks.cs
+++ b/CommunityLib/Hooks.cs
@@ -48,7 +48,7 @@ namespace CommunityLib
         /// <summary>
         /// This hook fires when a patch is requested between two locations. It recieves the location the path is from (locA), the location the path is aiming to reach (locB), the unit that is seeking the path (u), which is null if not applicable, and whether to consider safeMove (safeMove).
         /// If this hook returns any Location[] other than null, the rest of the pathFinding process will not happen. Instead, the function will return the array returned by this hook.
-        /// <para>All instances of this hook will run whenever a pathfinding call, even those after one which has not returned null.</para>
+        /// <para>No instances of this hook will run after one which has not returned null.</para>
         /// </summary>
         /// <param name="locA"></param>
         /// <param name="locB"></param>
@@ -63,7 +63,7 @@ namespace CommunityLib
         /// <summary>
         /// This hook fires when a patch is requested between a location and a social group. It recieves the location the path is from (loc), the social group the path is trying to reach (sg), the unit that is seeking the path (u), which is null if not applicable, and whether to consider safeMove (safeMove).
         /// If this hook returns any Location[] other than null, the rest of the pathFinding process will not happen. Instead, the function will return the array returned by this hook.
-        /// <para>All instances of this hook will run whenever a pathfinding call, even those after one which has not returned null.</para>
+        /// <para>No instances of this hook will run after one which has not returned null.</para>
         /// </summary>
         /// <param name="loc"></param>
         /// <param name="sg"></param>

--- a/CommunityLib/Hooks.cs
+++ b/CommunityLib/Hooks.cs
@@ -76,6 +76,33 @@ namespace CommunityLib
         }
 
         /// <summary>
+        /// This hook fires when the Community Library's pathfiding algorithm is called. It recieves the location the path is from (locA), the location the path is aiming to reach (locB), the unit that is seeking the path (u), which is null if not applicable, and the list of pathfinding delegates that have alsready been assigned to the path (pathfindingDelegates), including the unit's movement type and safemove requirements.
+        /// In order to modify how the path is calculated, add one or more new pathfinding delegates to the pathfindingDelegates variable.
+        /// </summary>
+        /// <param name="locA"></param>
+        /// <param name="locB"></param>
+        /// <param name="u"></param>
+        /// <param name="pathfindingDelegates"></param>
+        public virtual void onPopulatingPathfindingDelegates_Location(Location locA, Location locB, Unit u, List<Func<Location[], Location, Unit, bool>> pathfindingDelegates)
+        {
+            return;
+        }
+
+        /// <summary>
+        /// This hook fires when the Community Library's pathfiding algorithm is called. It recieves the location the path is from (loc), the social group the path is trying to reach (sg), the unit that is seeking the path (u), which is null if not applicable, and the list of pathfinding delegates that have alsready been assigned to the path (pathfindingDelegates), including the unit's movement type and safemove requirements.
+        /// In order to modify how the path is calculated, add one or more new pathfinding delegates to the pathfindingDelegates variable.
+        /// </summary>
+        /// <param name="loc"></param>
+        /// <param name="sg"></param>
+        /// <param name="u"></param>
+        /// <param name="pathfindingDelegates"></param>
+        public virtual void onPopulatingPathfindingDelegates_SocialGroup(Location loc, SocialGroup sg, Unit u, List<Func<Location[], Location, Unit, bool>> pathfindingDelegates)
+        {
+            return;
+        }
+
+
+        /// <summary>
         /// This hook fires when a unit is instructed to die. It recieves the Unit (u), a string representation of the cause (v), and the person, if applicable, that casued their death (killer).
         /// If this hook returns true, the rest of the death proccess will not happen. If you wish to keep the unit alive and prevent this check being performed multiple times per turn, make sure that their health is greater than 0, or their cause of death has been removed. The process which initially instructed the unit to die will still continue, so if you wish to keep the unit alive, make to sure to account for, and act in response to, the method of its death.
         /// <para>All instances of this hook will run whenever a unit is instructed to die, even those after one which has returned true.</para>

--- a/CommunityLib/HooksInternal.cs
+++ b/CommunityLib/HooksInternal.cs
@@ -149,6 +149,27 @@ namespace CommunityLib
 
         // Test items.
 
+        /*
+        public override Location[] interceptGetPathTo_Location(Location locA, Location locB, Unit u, bool safeMove)
+        {
+            if (u is UM_FirstDaughter)
+            {
+                Console.WriteLine("CommunityLib: intercepted get path to for First Daughter");
+                return ModCore.core.pathfinding.getPathTo(locA, locB, new List<Func<Location[], Location, Unit, bool>>(), u);
+            }
+            return null;
+        }
+
+        public override void onPopulatingPathfindingDelegates_Location(Location locA, Location locB, Unit u, List<Func<Location[], Location, Unit, bool>> pathfindingDelegates)
+        {
+            if (u is UM_FirstDaughter)
+            {
+                Console.WriteLine("CommunityLib: populating delegate for First Daughter");
+                pathfindingDelegates.Add(Pathfinding.delegate_LANDLOCKED);
+            }
+        }*/
+
+
         /*public override string onPopupHolyOrder_DisplayPageText(HolyOrder order, string s, int pageIndex)
         {
             if (order is HolyOrder_Witches && pageIndex == 0)

--- a/CommunityLib/Pathfinding.cs
+++ b/CommunityLib/Pathfinding.cs
@@ -19,6 +19,11 @@ namespace CommunityLib
             return location.isOcean || location.isCoastal;
         }
 
+        public static bool delegate_AQUATIC(Location[] currentPath, Location location, Unit u)
+        {
+            return location.isOcean;
+        }
+
         public static bool delegate_DESERT_ONLY(Location[] currentPath, Location location, Unit u)
         {
             return location.hex.terrain == Hex.terrainType.ARID || location.hex.terrain == Hex.terrainType.DESERT || location.hex.terrain == Hex.terrainType.DRY;
@@ -34,24 +39,37 @@ namespace CommunityLib
             return u == null || location.soc == null || !location.soc.hostileTo(u);
         }
 
-        public Location[] getPathTo(Location locA, Location locB, Func<Location[], Location, Unit, bool> pathfindingDelegate = null, Unit u = null, bool safeMove = false)
+        public static bool delegate_SHADOWBOUND(Location[] currentPath, Location location, Unit u)
         {
-            List<Func<Location[], Location, Unit, bool>> pathfindingDelegates = new List<Func<Location[], Location, Unit, bool>>();
+            int hp = 0;
 
-            if (pathfindingDelegate != null)
+            if (u != null)
             {
-                pathfindingDelegates.Add(pathfindingDelegate);
+                hp = u.hp;
             }
 
-            return getPathTo(locA, locB, pathfindingDelegates, u, safeMove);
+            if (u != null && location.getShadow() < 0.5)
+            {
+                if (currentPath.Where(l => l.getShadow() < 0.5).Count() + 1 < hp)
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            return true;
         }
 
-        public Location[] getPathTo(Location locA, Location locB, List<Func<Location[], Location, Unit, bool>> pathfindingDelegates = null, Unit u = null, bool safeMove = false)
+        public static bool delegate_SHADOW_ONLY(Location[] currentPath, Location location, Unit u)
         {
-            if (pathfindingDelegates == null)
-            {
-                pathfindingDelegates = new List<Func<Location[], Location, Unit, bool>>();
-            }
+            return location.getShadow() >= 0.5;
+        }
+
+        public Location[] getPathTo(Location locA, Location locB, Unit u = null, bool safeMove = false)
+        {
+
+            List<Func<Location[], Location, Unit, bool>>  pathfindingDelegates = new List<Func<Location[], Location, Unit, bool>>();
 
             if (u != null)
             {
@@ -137,24 +155,9 @@ namespace CommunityLib
             return null;
         }
 
-        public Location[] getPathTo(Location loc, SocialGroup sg, Func<Location[], Location, Unit, bool> pathfindingDelegate = null, Unit u = null, bool safeMove = false)
+        public Location[] getPathTo(Location locA, SocialGroup sg, Unit u = null, bool safeMove = false)
         {
             List<Func<Location[], Location, Unit, bool>> pathfindingDelegates = new List<Func<Location[], Location, Unit, bool>>();
-
-            if (pathfindingDelegate != null)
-            {
-                pathfindingDelegates.Add(pathfindingDelegate);
-            }
-
-            return getPathTo(loc, sg, pathfindingDelegates, u, safeMove);
-        }
-
-        public Location[] getPathTo(Location locA, SocialGroup sg, List<Func<Location[], Location, Unit, bool>> pathfindingDelegates = null, Unit u = null, bool safeMove = false)
-        {
-            if (pathfindingDelegates == null)
-            {
-                pathfindingDelegates = new List<Func<Location[], Location, Unit, bool>>();
-            }
 
             if (u != null)
             {

--- a/CommunityLib/Pathfinding.cs
+++ b/CommunityLib/Pathfinding.cs
@@ -19,7 +19,7 @@ namespace CommunityLib
             return location.isOcean || location.isCoastal;
         }
 
-        public static bool delegate_DESERT_ONLY (Location[] currentPath, Location location, Unit u)
+        public static bool delegate_DESERT_ONLY(Location[] currentPath, Location location, Unit u)
         {
             return location.hex.terrain == Hex.terrainType.ARID || location.hex.terrain == Hex.terrainType.DESERT || location.hex.terrain == Hex.terrainType.DRY;
         }
@@ -29,13 +29,55 @@ namespace CommunityLib
             return !location.isOcean;
         }
 
-        public static bool delegate_SAFE_MOVE (Location[] currentPath, Location location, Unit u)
+        public static bool delegate_SAFE_MOVE(Location[] currentPath, Location location, Unit u)
         {
             return u == null || location.soc == null || !location.soc.hostileTo(u);
         }
 
-        public Location[] getPathTo(Location locA, Location locB, Func<Location[], Location, Unit, bool> pathfindingDelegate = null, Unit u = null)
+        public Location[] getPathTo(Location locA, Location locB, Func<Location[], Location, Unit, bool> pathfindingDelegate = null, Unit u = null, bool safeMove = false)
         {
+            List<Func<Location[], Location, Unit, bool>> pathfindingDelegates = new List<Func<Location[], Location, Unit, bool>>();
+
+            if (pathfindingDelegate != null)
+            {
+                pathfindingDelegates.Add(pathfindingDelegate);
+            }
+
+            return getPathTo(locA, locB, pathfindingDelegates, u, safeMove);
+        }
+
+        public Location[] getPathTo(Location locA, Location locB, List<Func<Location[], Location, Unit, bool>> pathfindingDelegates = null, Unit u = null, bool safeMove = false)
+        {
+            if (pathfindingDelegates == null)
+            {
+                pathfindingDelegates = new List<Func<Location[], Location, Unit, bool>>();
+            }
+
+            if (u != null)
+            {
+                if (u.moveType == Unit.MoveType.AQUAPHIBIOUS)
+                {
+                    //Console.WriteLine("CommunityLib: Added Aquaphibious delegate");
+                    pathfindingDelegates.Add(delegate_AQUAPHIBIOUS);
+                }
+                else if (u.moveType == Unit.MoveType.DESERT_ONLY)
+                {
+                    //Console.WriteLine("CommunityLib: Added Desert only delegate");
+                    pathfindingDelegates.Add(delegate_DESERT_ONLY);
+                }
+
+                if (safeMove)
+                {
+                    //Console.WriteLine("CommunityLib: Added safe move delegate");
+                    pathfindingDelegates.Add(delegate_SAFE_MOVE);
+                }
+            }
+
+            foreach (Hooks hook in ModCore.core.GetRegisteredHooks())
+            {
+                hook.onPopulatingPathfindingDelegates_Location(locA, locB, u, pathfindingDelegates);
+            }
+
             HashSet<Location> locationHashes = new HashSet<Location> { locA };
             List<Location> locations = new List<Location> { locA };
             List<Location[]> paths = new List<Location[]> { new Location[] { locA } };
@@ -53,7 +95,17 @@ namespace CommunityLib
                     {
                         if (!locationHashes.Contains(neighbour))
                         {
-                            if (pathfindingDelegate != null && !pathfindingDelegate(paths[j], neighbour, u))
+                            bool valid = true;
+                            foreach (Func<Location[], Location, Unit, bool> pathfindingDelegate in pathfindingDelegates)
+                            {
+                                if (!pathfindingDelegate(paths[j], neighbour, u))
+                                {
+                                    valid = false;
+                                    break;
+                                }
+                            }
+
+                            if (!valid)
                             {
                                 continue;
                             }
@@ -85,8 +137,47 @@ namespace CommunityLib
             return null;
         }
 
-        public Location[] getPathTo(Location locA, SocialGroup sg, Func<Location[], Location, Unit, bool> pathfindingDelegate = null, Unit u = null)
+        public Location[] getPathTo(Location loc, SocialGroup sg, Func<Location[], Location, Unit, bool> pathfindingDelegate = null, Unit u = null, bool safeMove = false)
         {
+            List<Func<Location[], Location, Unit, bool>> pathfindingDelegates = new List<Func<Location[], Location, Unit, bool>>();
+
+            if (pathfindingDelegate != null)
+            {
+                pathfindingDelegates.Add(pathfindingDelegate);
+            }
+
+            return getPathTo(loc, sg, pathfindingDelegates, u, safeMove);
+        }
+
+        public Location[] getPathTo(Location locA, SocialGroup sg, List<Func<Location[], Location, Unit, bool>> pathfindingDelegates = null, Unit u = null, bool safeMove = false)
+        {
+            if (pathfindingDelegates == null)
+            {
+                pathfindingDelegates = new List<Func<Location[], Location, Unit, bool>>();
+            }
+
+            if (u != null)
+            {
+                if (u.moveType == Unit.MoveType.AQUAPHIBIOUS)
+                {
+                    pathfindingDelegates.Add(delegate_AQUAPHIBIOUS);
+                }
+                else if (u.moveType == Unit.MoveType.DESERT_ONLY)
+                {
+                    pathfindingDelegates.Add(delegate_DESERT_ONLY);
+                }
+
+                if (safeMove)
+                {
+                    pathfindingDelegates.Add(delegate_SAFE_MOVE);
+                }
+            }
+
+            foreach (Hooks hook in ModCore.core.GetRegisteredHooks())
+            {
+                hook.onPopulatingPathfindingDelegates_SocialGroup(locA, sg, u, pathfindingDelegates);
+            }
+
             HashSet<Location> locationHashes = new HashSet<Location> { locA };
             List<Location> locations = new List<Location> { locA };
             List<Location[]> paths = new List<Location[]> { new Location[] { locA } };
@@ -104,7 +195,17 @@ namespace CommunityLib
                     {
                         if (!locationHashes.Contains(neighbour))
                         {
-                            if (pathfindingDelegate != null && !pathfindingDelegate(paths[j], neighbour, u))
+                            bool valid = true;
+                            foreach (Func<Location[], Location, Unit, bool> pathfindingDelegate in pathfindingDelegates)
+                            {
+                                if (!pathfindingDelegate(paths[j], neighbour, u))
+                                {
+                                    valid = false;
+                                    break;
+                                }
+                            }
+
+                            if (!valid)
                             {
                                 continue;
                             }
@@ -168,7 +269,7 @@ namespace CommunityLib
             return result;
         }
 
-        private void shuffle (List<Location> locations, List<Location[]> paths)
+        private void shuffle(List<Location> locations, List<Location[]> paths)
         {
             if (locations.Count > 0)
             {

--- a/CommunityLib/Task_GoToPerformChallengeAtLocation.cs
+++ b/CommunityLib/Task_GoToPerformChallengeAtLocation.cs
@@ -93,16 +93,7 @@ namespace CommunityLib
 
             while (unit.movesTaken < unit.getMaxMoves())
             {
-                Location[] pathTo;
-                if (pathfindingDelegates == null)
-                {
-                    pathTo = unit.location.map.getPathTo(unit.location, target, unit, safeMove);
-                }
-                else
-                {
-                    pathTo = ModCore.core.pathfinding.getPathTo(unit.location, target, pathfindingDelegates, unit, safeMove);
-                }
-
+                Location[] pathTo = unit.location.map.getPathTo(unit.location, target, unit, safeMove);
                 if (pathTo == null || pathTo.Length < 2)
                 {
                     World.log("Path unavailable. Cancelling");

--- a/CommunityLib/Task_GoToPerformChallengeAtLocation.cs
+++ b/CommunityLib/Task_GoToPerformChallengeAtLocation.cs
@@ -1,5 +1,9 @@
-﻿using Assets.Code;
-using System;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Assets.Code;
 
 namespace CommunityLib
 {
@@ -7,22 +11,33 @@ namespace CommunityLib
     {
         public Location target;
         public bool safeMove;
-        public Func<Location[], Location, Unit, bool> pathfindingDelegate;
+        public List<Func<Location[], Location, Unit, bool>> pathfindingDelegates;
 
         public Task_GoToPerformChallengeAtLocation(Challenge c, Location loc, bool safeMove = false)
-            : base (c)
+            : base(c)
         {
             target = loc;
             this.safeMove = safeMove;
-            
+
         }
 
         public Task_GoToPerformChallengeAtLocation(Challenge c, Location loc, Func<Location[], Location, Unit, bool> pathfindingDelegate)
-            : base (c)
+            : base(c)
         {
             target = loc;
             safeMove = false;
-            this.pathfindingDelegate = pathfindingDelegate;
+            if (pathfindingDelegate != null)
+            {
+                pathfindingDelegates = new List<Func<Location[], Location, Unit, bool>> { pathfindingDelegate };
+            }
+        }
+
+        public Task_GoToPerformChallengeAtLocation(Challenge c, Location loc, List<Func<Location[], Location, Unit, bool>> pathfindingDelegates)
+            : base(c)
+        {
+            target = loc;
+            safeMove = false;
+            this.pathfindingDelegates = pathfindingDelegates;
         }
 
         public override string getLong()
@@ -79,13 +94,13 @@ namespace CommunityLib
             while (unit.movesTaken < unit.getMaxMoves())
             {
                 Location[] pathTo;
-                if (pathfindingDelegate == null)
+                if (pathfindingDelegates == null)
                 {
                     pathTo = unit.location.map.getPathTo(unit.location, target, unit, safeMove);
                 }
                 else
                 {
-                    pathTo = ModCore.core.pathfinding.getPathTo(unit.location, target, pathfindingDelegate, unit);
+                    pathTo = ModCore.core.pathfinding.getPathTo(unit.location, target, pathfindingDelegates, unit, safeMove);
                 }
 
                 if (pathTo == null || pathTo.Length < 2)

--- a/CommunityLib/Task_GoToPerformChallengeAtLocation.cs
+++ b/CommunityLib/Task_GoToPerformChallengeAtLocation.cs
@@ -11,7 +11,6 @@ namespace CommunityLib
     {
         public Location target;
         public bool safeMove;
-        public List<Func<Location[], Location, Unit, bool>> pathfindingDelegates;
 
         public Task_GoToPerformChallengeAtLocation(Challenge c, Location loc, bool safeMove = false)
             : base(c)
@@ -19,25 +18,6 @@ namespace CommunityLib
             target = loc;
             this.safeMove = safeMove;
 
-        }
-
-        public Task_GoToPerformChallengeAtLocation(Challenge c, Location loc, Func<Location[], Location, Unit, bool> pathfindingDelegate)
-            : base(c)
-        {
-            target = loc;
-            safeMove = false;
-            if (pathfindingDelegate != null)
-            {
-                pathfindingDelegates = new List<Func<Location[], Location, Unit, bool>> { pathfindingDelegate };
-            }
-        }
-
-        public Task_GoToPerformChallengeAtLocation(Challenge c, Location loc, List<Func<Location[], Location, Unit, bool>> pathfindingDelegates)
-            : base(c)
-        {
-            target = loc;
-            safeMove = false;
-            this.pathfindingDelegates = pathfindingDelegates;
         }
 
         public override string getLong()

--- a/CommunityLib/Task_GoToWilderness.cs
+++ b/CommunityLib/Task_GoToWilderness.cs
@@ -13,19 +13,10 @@ namespace CommunityLib
 
         public bool safeMove;
 
-        public Func<Location[], Location, Unit, bool> pathfindingDelegate;
-
         public Task_GoToWilderness(bool goToLand = false, bool safeMove = false)
         {
             this.goToLand = goToLand;
             this.safeMove = safeMove;
-        }
-
-        public Task_GoToWilderness(Func<Location[], Location, Unit, bool> pathfindingDelegate, bool goToLand = false)
-        {
-            this.pathfindingDelegate = pathfindingDelegate;
-            this.goToLand = goToLand;
-            safeMove = false;
         }
 
         public override string getShort()

--- a/CommunityLib/Task_GoToWilderness.cs
+++ b/CommunityLib/Task_GoToWilderness.cs
@@ -83,27 +83,13 @@ namespace CommunityLib
             while (unit.movesTaken < unit.getMaxMoves())
             {
                 Location[] pathTo;
-                if (pathfindingDelegate == null)
+                if (targetLocation == null)
                 {
-                    if (targetLocation == null)
-                    {
-                        pathTo = unit.map.getPathTo(unit.location, (SocialGroup)null, unit, safeMove);
-                    }
-                    else
-                    {
-                        pathTo = unit.map.getPathTo(unit.location, targetLocation, unit, safeMove);
-                    }
+                    pathTo = unit.map.getPathTo(unit.location, (SocialGroup)null, unit, safeMove);
                 }
                 else
                 {
-                    if (targetLocation == null)
-                    {
-                        pathTo = ModCore.core.pathfinding.getPathTo(unit.location, (SocialGroup)null, pathfindingDelegate, unit);
-                    }
-                    else
-                    {
-                        pathTo = ModCore.core.pathfinding.getPathTo(unit.location, targetLocation, pathfindingDelegate, unit);
-                    }
+                    pathTo = unit.map.getPathTo(unit.location, targetLocation, unit, safeMove);
                 }
 
                 if (pathTo == null || pathTo.Length < 2)

--- a/CommunityLib/UAENOverrideAI.cs
+++ b/CommunityLib/UAENOverrideAI.cs
@@ -34,8 +34,6 @@ namespace CommunityLib
             }
 
             // Test Articles
-            // populateUAA();
-            
         }
 
         private void populateDeepOne()
@@ -582,16 +580,6 @@ namespace CommunityLib
             reasonMsgs?.Add(new ReasonMsg("Base", utility));
 
             return utility;
-        }
-
-        private void populateUAA()
-        {
-            AgentAI.ControlParameters controlParams = new AgentAI.ControlParameters(false);
-            controlParams.pathfindingDeligate = Pathfinding.delegate_LANDLOCKED;
-            //Console.WriteLine("CommunityLib: Set pathfindingDeligate to delegate_SAFE_MOVE");
-
-            ModCore.core.GetAgentAI().RegisterAgentType(typeof(UAA), controlParams);
-            //Console.WriteLine("CommunityLib: Registered Agent Type UAA");
         }
     }
 }


### PR DESCRIPTION
Removed the ability to add a pathfinding delegate when calling the `Pathfidning.getPathTo` functions.
All pathfinding delegates are now added through the `onPopulatingPathfindingDelegates_` hooks.
This should prevent ambiguity when an agent's pathfinding is being performed through the Community Library's pathfinding system by multiple mods.

- `interceptGetPathTo_` hooks will no longer call hooks after a custom path has been returned.
- Removed pathfinding delegate variables and constructors from tasks.